### PR TITLE
Removed extra $session_lifetime declaration

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -40,7 +40,6 @@ class Zebra_Session
     private $flashdata;
     private $flashdata_varname;
     private $session_lifetime;
-    private $session_lifetime;
     private $link;
     private $lock_timeout;
     private $lock_to_ip;


### PR DESCRIPTION
Hey, I removed an extra declaration for `$session_lifetime` property, probably a line cloned by mistake in the code. Thanks a lot for your work on this package, I was just about to implement something awfully similar, saved me some time; I'll be sure to ping you whether I'll find anything to improve / repair.

And uhm.. sorry for bothering you with such a lame, short pull request :-)
