### PR TITLE
Fix Zebra_Session PHP7 incompatibily

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -579,6 +579,7 @@ class Zebra_Session
 
         ') or die($this->_mysql_error());
 
+        return true;
     }
 
     /**
@@ -698,19 +699,7 @@ class Zebra_Session
 
         // if anything happened
         if ($result) {
-
-            // note that after this type of queries, mysqli_affected_rows() returns
-            // - 1 if the row was inserted
-            // - 2 if the row was updated
-
-            // if the row was updated
-            // return TRUE
-            if (@$this->_mysql_affected_rows() > 1) return true;
-
-            // if the row was inserted
-            // return an empty string
-            else return '';
-
+            return true;
         }
 
         // if something went wrong, return false


### PR DESCRIPTION
Using Zebra_Session with PHP7 causes any page that opens a session to hang without triggering any error messages.

Investigation showed this to be because write was sometimes returning a non-boolean, where the PHP documentation (http://php.net/manual/en/class.sessionhandler.php) states that write MUST return a boolean value.