### PR TITLE
Warning: session_destroy(): Trying to destroy uninitialized session

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -266,7 +266,7 @@ class Zebra_Session {
             );
 
             // if a session is already started, destroy it first
-            if (session_id() == '') session_destroy();
+            if (session_id() !== '') session_destroy();
 
             // start session
             session_start();


### PR DESCRIPTION
Hello @stefangabos 
After installing the package all works fine but I get this warning:
`Warning: session_destroy(): Trying to destroy uninitialized session in D:\wamp\www\csvinew\vendor\stefangabos\zebra_session\Zebra_Session.php on line 269`

Looking at the code I think it is because you are trying to destroy a session that actually doesn't exist while you want to destroy an existing session.

Hereby my tiny contribution. If I am wrong, feel free to close this :)