### PR TITLE
Added backtick quotation for table name in read query.

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -500,7 +500,7 @@ class Zebra_Session {
             SELECT
                 session_data
             FROM
-                ' . $this->table_name . '
+                `' . $this->table_name . '`
             WHERE
                 session_id = "' . $this->_mysql_real_escape_string($session_id) . '" AND
                 session_expire > "' . time() . '" AND


### PR DESCRIPTION
This is a small bugfix. Using non-default table name for session data storage could lead to errors i.e. if table name contains spaces.
This fix could be further expanded to include table name escaping using proper mysql functions to quote identifiers.