### PR TITLE
Add option to disable automatically starting the session

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -26,7 +26,7 @@ class Zebra_Session {
 
     /**
      *  Constructor of class. Initializes the class and automatically calls
-     *  {@link http://php.net/manual/en/function.session-start.php start_session()}.
+     *  {@link http://php.net/manual/en/function.session-start.php session_start()}.
      *
      *  <code>
      *  // first, connect to a database containing the sessions table
@@ -200,9 +200,13 @@ class Zebra_Session {
      *
      *                                          Default is <i>60</i>
      *
+     *  @param  boolean     $start_session      (Optional) Whether to start the session by default after object
+     *                                          construction.
+     *
+     *                                          Default is TRUE.
      *  @return void
      */
-    public function __construct(&$link, $security_code, $session_lifetime = '', $lock_to_user_agent = true, $lock_to_ip = false, $gc_probability = '', $gc_divisor = '', $table_name = 'session_data', $lock_timeout = 60) {
+    public function __construct(&$link, $security_code, $session_lifetime = '', $lock_to_user_agent = true, $lock_to_ip = false, $gc_probability = '', $gc_divisor = '', $table_name = 'session_data', $lock_timeout = 60, $start_session = true) {
 
         // continue if the provided link is valid
         if ($link instanceof MySQLi && $link->connect_error === null) {
@@ -269,7 +273,8 @@ class Zebra_Session {
             if (session_id() !== '') session_destroy();
 
             // start session
-            session_start();
+            if ($start_session)
+                session_start();
 
             // the name for the session variable that will be created upon script execution
             // and destroyed when instantiating this library, and which will hold information


### PR DESCRIPTION
This adds an option to skip calling `session_start()` during construction.

I was trying to integrate this into an existing application via `auto_prepend_file` that also set some further session settings with `ini_set` and called `session_start()` itself. However, since Zebra_Session had already started the session, it prevented the existing application from calling `ini_set` for session settings, since the session had already begun. By adding this option it allows for Zebra_Session to skip starting the session if you're trying to integrating it with an application that already performs other session setup.