### PR TITLE
Temporary solution #[\AllowDynamicProperties] for php 8.2

### DIFF
--- a/Zebra_Session.php
+++ b/Zebra_Session.php
@@ -14,6 +14,7 @@
  *  @license    https://www.gnu.org/licenses/lgpl-3.0.txt GNU LESSER GENERAL PUBLIC LICENSE
  *  @package    Zebra_Session
  */
+#[\AllowDynamicProperties]
 class Zebra_Session {
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "stefangabos/zebra_session",
+    "name": "i07/zebra_session",
     "type": "library",
     "description": "A drop-in replacement for PHP's default session handler which stores session data in a MySQL database, providing better performance, better security and protection against session fixation and session hijacking",
     "keywords": ["session", "locking", "flash", "flashdata", "fixation", "hijack", "mysqli", "mysql", "database"],


### PR DESCRIPTION
#[\AllowDynamicProperties] annotation added, to remove deprecation warnings in php 8.2 and higher. This is not a solution but simply to allow dynamic properties for the Zebra_Session class in php 8.2 and higher.